### PR TITLE
(Optional) Feature Request: !remind command accessible by Mods & Admins

### DIFF
--- a/commands/index.ts
+++ b/commands/index.ts
@@ -10,6 +10,7 @@ import Translate from "./translate";
 import Stats from "./stats";
 import Stonk from "./stonk";
 import Spongebob from "./spongebob";
+import Remind from "./remind";
 
 // To register a command, import it above and add it to this array.
 export const commands: Command[] = [
@@ -23,6 +24,7 @@ export const commands: Command[] = [
   Roulette,
   PingPong,
   Contribute,
+  Remind
 ];
 
 export type CommandDefinition = {

--- a/commands/remind.ts
+++ b/commands/remind.ts
@@ -8,8 +8,14 @@ export const description: CommandDefinition = {
   keys: ["remind"],
 };
 
+/**
+ * Splits the paramaters provided into an array 
+ * Will quit early if Regex match is undefiend or if code syntax is missing
+ * @param content The message provided by the user.
+ * @return An array of two elements: the target role, and the message to send
+ */
 function parseMessage(content : string) : string[] {
-  const paramArray = content.replace("!remind ", "").match(/^(\S+)\s(.*)/)?.slice(1);
+  const paramArray = content.replace("!remind ", "").match(/^(\S+)\s(.*)/)?.slice(1); 
   if (paramArray === undefined) return []; // Quit if invalid format was passed 
   if(paramArray[0].match(/`/gi)?.length !== 2) return [] // Quit if missing code syntax
   paramArray[0] = paramArray[0].slice(1,-1); // Slice off the code syntax (no longer needed)
@@ -21,7 +27,7 @@ export const action = (message: Message, key: string) => {
     message.author.send("Call me in a server!");
     return;
   } 
-  
+
   const highestRole = message.member?.roles.highest.name // Request must be from Admin or Mod
   if (!(highestRole === "Admin" || highestRole === "Mod")) {
     message.reply("Sorry! I only accept !remind requests from Admins or Mods");

--- a/commands/remind.ts
+++ b/commands/remind.ts
@@ -43,7 +43,7 @@ export const action = (message: Message, key: string) => {
   // Fetch all members whose highest role is equal to the role mentioned in the command
   const memberList = message.guild.members.cache.filter((m) => m.roles.highest.name === paramArray[0]);
   if (memberList.size == 0) { // Quit if role is invalid
-    message.reply("I don't recognize that role, perhaps there is a typo in it?");
+    message.reply("I don't recognize that role, perhaps there is a typo in it, or no user is categorized by it.");
     return;
   }
 

--- a/commands/remind.ts
+++ b/commands/remind.ts
@@ -54,6 +54,7 @@ export const action = (message: Message, key: string) => {
       user.send(paramArray[1]); // Send the current member a DM
     })
   }
+  message.reply("Succesfully sent to " + memberList.size + " members");
 };
 
 export const command: Command = {

--- a/commands/remind.ts
+++ b/commands/remind.ts
@@ -1,0 +1,54 @@
+import { Message, UserResolvable } from "discord.js";
+import { Command, CommandDefinition, Action } from ".";
+
+export const description: CommandDefinition = {
+  name: "Reminder Bot",
+  description: "Reminds a subset of users with a specific message. Only usable by Admins & Mods.",
+  usage: ["!remind `<role>` <message>"],
+  keys: ["remind"],
+};
+
+function parseMessage(content : string) : string[] {
+  const paramArray = content.replace("!remind ", "").match(/^(\S+)\s(.*)/)?.slice(1);
+  if (paramArray === undefined) return []; // Quit if invalid format was passed 
+  paramArray[0] = paramArray[0].slice(1, -1); // Take off the ` ` symbols surround the role
+  if (paramArray[0] === "") return []; // Quit if user didn't wrap role with ` `
+  return paramArray;
+}
+
+export const action = (message: Message, key: string) => {
+  if (!message.guild) { // Cannot be called outside of a server
+    message.author.send("Call me in a server!");
+    return;
+  } 
+  const highestRole = message.member?.roles.highest.name // Request must be from Admin or Mod
+  if (!(highestRole === "Admin" || highestRole === "Mod")) {
+    message.reply("Sorry! I only accept !remind requests from Admins or Mods");
+    return;
+  }
+
+  const paramArray  = parseMessage(message.content); // Parse the target role and message to send
+  if (paramArray.length === 0) {
+    message.reply("I couldn't understand your request... For example you can do !remind `Mod` Hi all Mods!. Please make sure to wrap the role in `code syntax`!");
+    return;
+  }
+
+  const targetRole = paramArray[0];
+  const messageToSend = paramArray[1];
+  
+  // Fetch all members whose highest role is equal to the role mentioned in the command
+  const memberList = message.guild.members.cache.filter((m) => m.roles.highest.name === targetRole);
+  const membersJSON : any = memberList.toJSON(); 
+  for (const key in membersJSON) { // Iterate through each member JSON
+    message.guild.members.fetch(membersJSON[key].userID) // Fetch the member based on ID
+    .then((user : any) => {
+      user.send(messageToSend); // Send the current member a DM
+    })
+  }
+};
+
+export const command: Command = {
+  definition: description,
+  action: action,
+};
+export default command;

--- a/commands/remind.ts
+++ b/commands/remind.ts
@@ -41,7 +41,7 @@ export const action = (message: Message, key: string) => {
   }
   
   // Fetch all members whose highest role is equal to the role mentioned in the command
-  const memberList = message.guild.members.cache.filter((m) => m.roles.highest.name === paramArray[0]);
+  const memberList = message.guild.members.cache.filter((m) => m.roles.highest.name === paramArray[0] && !m.user.bot);
   if (memberList.size == 0) { // Quit if role is invalid
     message.reply("I don't recognize that role, perhaps there is a typo in it, or no user is categorized by it.");
     return;

--- a/commands/remind.ts
+++ b/commands/remind.ts
@@ -12,7 +12,7 @@ function parseMessage(content : string) : string[] {
   const paramArray = content.replace("!remind ", "").match(/^(\S+)\s(.*)/)?.slice(1);
   if (paramArray === undefined) return []; // Quit if invalid format was passed 
   if(paramArray[0].match(/`/gi)?.length !== 2) return [] // Quit if missing code syntax
-  paramArray[0] = paramArray[0].slice(1,-1);
+  paramArray[0] = paramArray[0].slice(1,-1); // Slice off the code syntax (no longer needed)
   return paramArray;
 }
 

--- a/commands/remind.ts
+++ b/commands/remind.ts
@@ -50,11 +50,16 @@ export const action = (message: Message, key: string) => {
   const membersJSON : any = memberList.toJSON(); 
   for (const key in membersJSON) { // Iterate through each member JSON
     message.guild.members.fetch(membersJSON[key].userID) // Fetch the member based on ID
-    .then((user : any) => {
-      user.send(paramArray[1]); // Send the current member a DM
+    .then((user : any) => { // Send the current member a DM
+        user.send(
+            `**You've got mail! :mailbox_with_mail:**\n` + 
+            `You are receiving this message because you are categorized under the following role: ${paramArray[0]}\n\n*` +
+            paramArray[1] + 
+            `*\n\nThis automated message was sent to you on behalf of **${message.author.username}** from the **${message.guild?.name}**`
+        ); 
     })
   }
-  message.reply("Succesfully sent to " + memberList.size + " members");
+  message.reply("message has been sent to " + memberList.size + " members");
 };
 
 export const command: Command = {


### PR DESCRIPTION
See https://github.com/ieee-uottawa/SITE-Bot/issues/21


# Demo

Step 1) This user has no role: 
<img src="https://user-images.githubusercontent.com/43019056/104947489-d55d8680-5989-11eb-92e1-f6a178f5d4ad.png"  width="400"/>

Step 2) This user is an Admin: 
<img src="https://user-images.githubusercontent.com/43019056/104947530-e1e1df00-5989-11eb-9973-755d7a758891.png"  width="400"/>

Step 3) Admin `amaha` sends a !remind command to all users *whose highest role is `@everyone`*:
<img src="https://user-images.githubusercontent.com/43019056/104949207-90871f00-598c-11eb-9a68-0ad239886e93.png"  width="400"/>

Step 4) This means that all users that have yet to assign themselves with a proper role will get the following message:
<img src="https://user-images.githubusercontent.com/43019056/104960913-43fb0e00-59a3-11eb-9dde-84db29b6853a.png"  width="600"/>

