### PR TITLE
Fix: Update !remind & !stats behaviour

### DIFF
--- a/commands/remind.ts
+++ b/commands/remind.ts
@@ -40,13 +40,15 @@ export const action = (message: Message, key: string) => {
     return;
   }
   
-  // Fetch all members whose highest role is equal to the role mentioned in the command
-  const memberList = message.guild.members.cache.filter((m) => m.roles.highest.name === paramArray[0] && !m.user.bot);
-  if (memberList.size == 0) { // Quit if role is invalid
+  // Fetch the role ID of the role name provided
+  const roleId = message.guild.roles.cache.find(r => r.name === paramArray[0])?.id;
+  if (roleId === undefined) { // Quit if role is invalid
     message.reply("I don't recognize that role, perhaps there is a typo in it, or no user is categorized by it.");
     return;
   }
-
+  
+  // Fetch all members that are a part of the role provided
+  const memberList = message.guild.members.cache.filter((m) => m.roles.cache.has(roleId) && !m.user.bot);
   const membersJSON : any = memberList.toJSON(); 
   for (const key in membersJSON) { // Iterate through each member JSON
     message.guild.members.fetch(membersJSON[key].userID) // Fetch the member based on ID

--- a/commands/remind.ts
+++ b/commands/remind.ts
@@ -47,7 +47,7 @@ export const action = (message: Message, key: string) => {
     return;
   }
   
-  // Fetch all members that are a part of the role provided
+  // Fetch all members that are a part of the retrieved roleID 
   const memberList = message.guild.members.cache.filter((m) => m.roles.cache.has(roleId) && !m.user.bot);
   const membersJSON : any = memberList.toJSON(); 
   for (const key in membersJSON) { // Iterate through each member JSON

--- a/commands/stats.ts
+++ b/commands/stats.ts
@@ -23,7 +23,7 @@ export const action = (message: Message, key: string) => {
   const botCount = message.guild.members.cache.filter((m) => m.user.bot).size;
   const userCount = totalCount - botCount;
 
-  // Coun users who are still categorized as "New Member"
+  // Count users who are still categorized as "New Member"
   const newMemberRoleID = message.guild.roles.cache.find(r => r.name === "New Member")?.id!;
   const newMemberCount = message.guild.members.cache.filter((m) => m.roles.cache.has(newMemberRoleID)).size;
 
@@ -37,15 +37,15 @@ export const action = (message: Message, key: string) => {
     const roleCount =
       message.guild?.roles.cache.get(roleData.id)?.members.size || 0; // Is 0 if undefined
 
-    // If the role is deleted, is @everyone, is a bot role, or has a count of 0, skip
+    // Do not include any of the roles satisfying any of these criterias: 
     if (
       roleData.deleted ||
+      roleCount === 0 || 
       roleName === "@everyone" ||
       roleName === "YAGPDB.xyz" ||
       roleName === "Bot" ||
-      roleName === "New Member" ||
-      roleCount === 0 ||
-      roleName.toLowerCase().match(/([a-z][a-z][a-z][0-9][0-9][0-9][0-9])/g)
+      roleName === "New Member" || // Skip New Member role (we already have it)
+      roleName.toLowerCase().match(/([a-z][a-z][a-z][0-9][0-9][0-9][0-9])/g) // Skip all course code roles
     )
       continue;
     

--- a/commands/stats.ts
+++ b/commands/stats.ts
@@ -21,8 +21,11 @@ export const action = (message: Message, key: string) => {
   }
   const totalCount = message.guild.memberCount;
   const botCount = message.guild.members.cache.filter((m) => m.user.bot).size;
-  const noRoleCount = message.guild.members.cache.filter((m) => m.roles.highest.name === "@everyone").size;
   const userCount = totalCount - botCount;
+
+  // Coun users who are still categorized as "New Member"
+  const newMemberRoleID = message.guild.roles.cache.find(r => r.name === "New Member")?.id!;
+  const newMemberCount = message.guild.members.cache.filter((m) => m.roles.cache.has(newMemberRoleID)).size;
 
   //Get role counts - organized under year, program, association, pronoun & miscellaneous
   let rollCounts: {[key: string]: string[]} = {year:[], program:[], assoc:[], pronoun:[], misc:[]};
@@ -40,6 +43,7 @@ export const action = (message: Message, key: string) => {
       roleName === "@everyone" ||
       roleName === "YAGPDB.xyz" ||
       roleName === "Bot" ||
+      roleName === "New Member" ||
       roleCount === 0 ||
       roleName.toLowerCase().match(/([a-z][a-z][a-z][0-9][0-9][0-9][0-9])/g)
     )
@@ -53,7 +57,7 @@ export const action = (message: Message, key: string) => {
   }
 
   const data =
-    `here are the user stats for **${message.guild?.name}**  :bar_chart: \n\`User Count: ${userCount}\`\n\`Bot Count: ${botCount}\`\n\`No Role Count: ${noRoleCount}\`\n` +
+    `here are the user stats for **${message.guild?.name}**  :bar_chart: \n\`User Count: ${userCount}\`\n\`Bot Count: ${botCount}\`\n\`New Member Count: ${newMemberCount}\`\n` +
     rollCounts.year.sort().join("\n") + `\n` + 
     rollCounts.assoc.join("\n") + `\n` +
     rollCounts.program.join("\n") + `\n` +


### PR DESCRIPTION
[Previously](https://github.com/ieee-uottawa/SITE-Bot/pull/22) the `!remind` command would only check if a user's highest role is equal to the role provided. 

Now, as long as a user is occupying that role, **regardless of where the role is in the user's role hierarchy**, it will include it in its private DM list. 

Also adding a fix to !stats; we no longer check for the `No Role Count`, but instead for the `New Member Count`. 